### PR TITLE
Fix uninitialised RpiInfo object

### DIFF
--- a/cli/rpi.js
+++ b/cli/rpi.js
@@ -171,10 +171,11 @@ class Main extends homebridgeLib.CommandLineTool {
 
     let info
     let state
+    let rpiInfo = new RpiInfo()
     if (this._clargs.options.host == null) {
-      info = await RpiInfo.getCpuInfo()
+      info = await rpiInfo.getCpuInfo()
       try {
-        state = await RpiInfo.getState()
+        state = await rpiInfo.getState()
       } catch (error) {
         // this.error(error)
         this.error(error.message.slice(0, error.message.length - 1)) // FIXME
@@ -183,10 +184,10 @@ class Main extends homebridgeLib.CommandLineTool {
     } else {
       try {
         const cpuInfo = await this.pi.readFile('/proc/cpuinfo')
-        info = RpiInfo.parseCpuInfo(cpuInfo)
+        info = rpiInfo.parseCpuInfo(cpuInfo)
         await this.pi.shell('getState')
         const text = await this.pi.readFile('/tmp/getState.json')
-        state = RpiInfo.parseState(text)
+        state = rpiInfo.parseState(text)
       } catch (error) {
         this.error(error)
         return


### PR DESCRIPTION
Hey, I just installed your plugin and I discovered that `rpi info` command was not working on my Raspberry Pi

```
pi@raspberrypi:~ $ rpi info
rpi info: error: TypeError: RpiInfo.New is not a function
    at Main.info (/usr/lib/node_modules/homebridge-rpi/cli/rpi.js:174:27)
    at Main.main (/usr/lib/node_modules/homebridge-rpi/cli/rpi.js:129:39)
    at Object.<anonymous> (/usr/lib/node_modules/homebridge-rpi/cli/rpi.js:232:12)
    at Module._compile (internal/modules/cjs/loader.js:1133:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1153:10)
    at Module.load (internal/modules/cjs/loader.js:977:32)
    at Function.Module._load (internal/modules/cjs/loader.js:877:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:74:12)
    at internal/main/run_main_module.js:18:47
```

I could fix it with the changes you can see in this PR. It may not be the best code, because my JS is rather poor.