### PR TITLE
Add arm64 (Ubuntu 20.10) as supported platform

### DIFF
--- a/lib/RpiInfo.js
+++ b/lib/RpiInfo.js
@@ -102,8 +102,8 @@ class RpiInfo extends events.EventEmitter {
     * or when `/proc/cpuinfo` or `/proc/1/sched` cannot be read.
     */
   async getCpuInfo () {
-    if (os.platform() !== 'linux' || os.arch() !== 'arm') {
-      throw new Error(`running ${os.platform()} on ${os.arch()}`)
+    if (os.platform() !== 'linux' || !os.arch().match(/^(arm|arm64)$/)) {
+      throw new Error(`CpuInfo not available running ${os.platform()} on ${os.arch()}`)
     }
     /** Emitted when a file is read.
       * @event RpiInfo#readFile


### PR DESCRIPTION
I'm running homebridge-rpi on Ubuntu 20.10 (64 bit) and the `rpi` command failed, so this is a simple fix.

Let me know if you'd like me to update the README with instructions for getting things going on Ubuntu.