### PR TITLE
Fix reversed switches false click

### DIFF
--- a/lib/RpiService/GpioOutput/GpioSwitch.js
+++ b/lib/RpiService/GpioOutput/GpioSwitch.js
@@ -60,7 +60,7 @@ class GpioSwitch extends GpioOutput {
   }
 
   update (value) {
-    this.debug('gpio %d: %s', this.gpio, value ? 'high' : 'low')
+    this.debug('update gpio %d: %s', this.gpio, value ? 'on' : 'off')
     if (this.resetTimeout != null) {
       clearTimeout(this.resetTimeout)
       delete this.resetTimeout

--- a/lib/RpiService/GpioOutput/GpioSwitch.js
+++ b/lib/RpiService/GpioOutput/GpioSwitch.js
@@ -59,6 +59,16 @@ class GpioSwitch extends GpioOutput {
     }
   }
 
+  async init () {
+    if (this.pulse != null) {
+      this.debug('GpioSwitch init gpio %d: setting %s', this.gpio, this.params.reversed ? 'high' : 'low')
+      await this.pi.command(
+        PigpioClient.commands.WRITE, this.gpio, this.params.reversed ? 1 : 0
+      )
+    }
+    return super.init()
+  }
+
   update (value) {
     this.debug('update gpio %d: %s', this.gpio, value ? 'on' : 'off')
     if (this.resetTimeout != null) {


### PR DESCRIPTION
This is to avoid momentarily driving the pin in the incorrect level.

Brief phantom "presses" of a "reverse" GpioSwitch have been reported a
few times and this is the cause.

A good example is a GPO controlling a relay which controls a physical
button like a garage door opener remote wall control. On Pi boot, the
GpioOutput would set the mode to output, but pigpiod has the value 0
configured by default. This would result in a permanent press of the
button, which could i this example open a garage door.

Raspberry Pi's first few GPIO pins as pulled high on power on. This
means if you want to wire the Pi GPO pin directly to the relay, you must
absolutely must set the relay to active low, and use the N.O. relay
contacts to operate the button.

In this configuration (reverse and pulse), the desired "unpressed
switch" state must be programmed into PigpioD prior to setting the pin's
mode to output.

The "unpressed" depends on the "reverse" property.